### PR TITLE
The yaml package is required to load the YAML config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,12 @@ $ cd csp-billing-adapter
 $ pip install -e .[dev]
 ```
 
-csp-billing-adapter is now installed in the active virtual environment in development
+`csp-billing-adapter` is now installed in the active virtual environment in development
 mode.
+
+*NOTE*: You will need to create a `~/.config/csp-billing-adapter.yaml` with
+appropriate configuration settings to be able to run the `csp-billing-adapter`
+command.
 
 Dev Requirements
 ================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dateutil
 pluggy
+PyYAML


### PR DESCRIPTION
Add `pyyaml` as a required package in requirements.txt.

Also update the CONTRIBUTING.md to reflect that need for a config
file, ~/.config/csp-billing-adapter.yaml.

Fixes: #23