### PR TITLE
Add an in-memory cache implementation

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -37,7 +37,7 @@ from csp_billing_adapter.utils import get_now, date_to_string
 from csp_billing_adapter import hookspecs
 from csp_billing_adapter import csp_hookspecs
 from csp_billing_adapter import storage_hookspecs
-from csp_billing_adapter import local_csp, product_api
+from csp_billing_adapter import local_csp, product_api, memory_cache
 
 namespace = 'neuvector-csp-billing-adapter'
 
@@ -50,6 +50,7 @@ def get_plugin_manager():
     pm.load_setuptools_entrypoints('csp_billing_adapter')
     pm.register(local_csp)
     pm.register(product_api)
+    pm.register(memory_cache)
     return pm
 
 

--- a/csp_billing_adapter/memory_cache.py
+++ b/csp_billing_adapter/memory_cache.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+
+import csp_billing_adapter
+
+from csp_billing_adapter.config import Config
+
+memory_cache = {}
+
+log = logging.getLogger('CSPBillingAdapter')
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def get_cache(config: Config):
+    """Retrieve cache content from in-memory cache."""
+
+    log.info("Retrieved Cache Content: %s", memory_cache)
+
+    return {**memory_cache}
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def update_cache(config: Config, cache: dict, replace: bool = False):
+    """Update in-memory cache with now content, replacing if specified."""
+
+    global memory_cache
+
+    if replace:
+        old_cache = {}
+    else:
+        old_cache = memory_cache
+
+    memory_cache = {**old_cache, **cache}
+
+    log.info("Updated Cache Content: %s", memory_cache)
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def save_cache(config: Config, cache: dict):
+    """Save specified content as new in-memory cache contents."""
+
+    update_cache(config, cache, replace=True)


### PR DESCRIPTION
Add a new in-memory cache implementation that can be used for basic
testing & verification of the csp-billing-adapter core functionality.
