### PR TITLE
Add in-memory csp_config implementation

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -37,7 +37,12 @@ from csp_billing_adapter.utils import get_now, date_to_string
 from csp_billing_adapter import hookspecs
 from csp_billing_adapter import csp_hookspecs
 from csp_billing_adapter import storage_hookspecs
-from csp_billing_adapter import local_csp, product_api, memory_cache
+from csp_billing_adapter import (
+    local_csp,
+    product_api,
+    memory_cache,
+    memory_csp_config
+)
 
 
 def get_plugin_manager():
@@ -49,6 +54,7 @@ def get_plugin_manager():
     pm.register(local_csp)
     pm.register(product_api)
     pm.register(memory_cache)
+    pm.register(memory_csp_config)
     return pm
 
 

--- a/csp_billing_adapter/memory_csp_config.py
+++ b/csp_billing_adapter/memory_csp_config.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+
+import csp_billing_adapter
+
+from csp_billing_adapter.config import Config
+
+memory_csp_config = {}
+
+log = logging.getLogger('CSPBillingAdapter')
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def get_csp_config(config: Config):
+    """Retrieve csp_config content from in-memory csp_config."""
+
+    log.info("Retrieved CSP Config Content: %s", memory_csp_config)
+
+    return {**memory_csp_config}
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def update_csp_config(config: Config, csp_config: dict, replace: bool):
+    """
+    Update in-memory csp_config with new content, replacing if specified.
+    """
+
+    global memory_csp_config
+
+    if replace:
+        old_csp_config = {}
+    else:
+        old_csp_config = memory_csp_config
+
+    memory_csp_config = {**old_csp_config, **csp_config}
+
+    log.info("Updated CSP Config Content: %s", memory_csp_config)
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def save_csp_config(config: Config, csp_config: dict):
+    """Save specified content as new in-memory csp_config contents."""
+
+    update_csp_config(config, csp_config, replace=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -53,12 +53,15 @@ def cba_config(data_dir, request):
 def cba_pm(cba_config):
     """
     Fixture returning an initialized plugin manager instance, based
-    on supplied config. Also needs to reset the cache to empty to
-    simulate a fresh start.
+    on supplied config. Also needs to reset the in-memory cache and
+    csp_config to empty to simulate a fresh start.
     """
     pm = get_plugin_manager()
 
     # reset the in-memory cache to empty
     pm.hook.save_cache(config=cba_config, cache=dict())
+
+    # reset the in-memory csp_config to empty
+    pm.hook.save_csp_config(config=cba_config, csp_config=dict())
 
     return pm

--- a/tests/unit/test_memory_csp_config.py
+++ b/tests/unit/test_memory_csp_config.py
@@ -1,0 +1,94 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Unit tests for the csp_billing_adapter.memory_csp_config when called
+# via hooks
+#
+
+def test_memory_get_csp_config(cba_pm, cba_config):
+    # csp_config should initially be empty
+    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
+
+
+def test_memory_csp_config_update_merge(cba_pm, cba_config):
+    test_data1 = dict(a=1, b=2)
+    test_data2 = dict(a=10, c=12)
+    test_data3 = {**test_data1, **test_data2}
+
+    # csp_config should initially be empty
+    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
+
+    cba_pm.hook.update_csp_config(
+        config=cba_config,
+        csp_config=test_data1,
+        replace=False
+    )
+
+    assert cba_pm.hook.get_csp_config(config=cba_config) == test_data1
+
+    cba_pm.hook.update_csp_config(
+        config=cba_config,
+        csp_config=test_data2,
+        replace=False
+    )
+
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+
+    assert csp_config['a'] != test_data1['a']
+    assert csp_config['b'] == test_data1['b']
+    assert csp_config['c'] == test_data2['c']
+    assert csp_config == test_data3
+
+
+def test_memory_csp_config_update_replace(cba_pm, cba_config):
+    test_data1 = dict(a=1, b=2)
+    test_data2 = dict(c=3, d=4)
+
+    # csp_config should initially be empty
+    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
+
+    cba_pm.hook.update_csp_config(
+        config=cba_config,
+        csp_config=test_data1,
+        replace=False
+    )
+
+    assert cba_pm.hook.get_csp_config(config=cba_config) == test_data1
+
+    cba_pm.hook.update_csp_config(
+        config=cba_config,
+        csp_config=test_data2,
+        replace=True
+    )
+
+    assert cba_pm.hook.get_csp_config(config=cba_config) == test_data2
+
+
+def test_memory_csp_config_save(cba_pm, cba_config):
+    test_data1 = dict(a=1, b=2)
+    test_data2 = dict(c=3, d=4)
+
+    # csp_config should initially be empty
+    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
+
+    cba_pm.hook.save_csp_config(config=cba_config, csp_config=test_data1)
+
+    assert cba_pm.hook.get_csp_config(config=cba_config) == test_data1
+
+    cba_pm.hook.save_csp_config(config=cba_config, csp_config=test_data2)
+
+    assert cba_pm.hook.get_csp_config(config=cba_config) == test_data2


### PR DESCRIPTION
Similarly to the in-memory cache, this allows for functional testing without the need to load additional plugins.

Added unit tests to exercise the in-memory csp_config with the hook interfaces.