### PR TITLE
Add missing copyrights to some of the tests files.

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import pathlib
 import yaml
 
@@ -46,7 +62,10 @@ def cba_config(data_dir, request):
 
     config_path = data_dir / config_file
 
-    return yaml.safe_load(config_path.open())
+    with config_path.open() as conf_fp:
+        config = yaml.safe_load(conf_fp)
+
+    return config
 
 
 @pytest.fixture

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -1,4 +1,20 @@
 #
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
 # Unit tests for the csp_billing_adapter.memory_cache when called via hooks
 #
 


### PR DESCRIPTION
Also switch the cba_config fixture to use with as wrapping for the yaml.safe_load; forgot to make this change in my previous updates.