### PR TITLE
Unit tests for misc modules

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,6 +20,7 @@ import yaml
 import pytest
 
 from csp_billing_adapter.adapter import get_plugin_manager
+from csp_billing_adapter.config import Config
 
 
 def pytest_configure(config):
@@ -65,7 +66,7 @@ def cba_config(data_dir, request):
     with config_path.open() as conf_fp:
         config = yaml.safe_load(conf_fp)
 
-    return config
+    return Config(config)
 
 
 @pytest.fixture

--- a/tests/unit/test_csp_config.py
+++ b/tests/unit/test_csp_config.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Unit tests for the csp_billing_adapter.csp_config
+#
+
+import datetime
+
+from csp_billing_adapter.csp_config import create_csp_config
+from csp_billing_adapter.utils import string_to_date
+
+
+def test_create_csp_config(cba_pm, cba_config):
+    # csp_config should initially be empty
+    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
+
+    create_csp_config(cba_pm.hook, cba_config)
+
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+
+    assert 'billing_api_access_ok' in csp_config
+    assert csp_config['billing_api_access_ok'] is True
+    assert 'timestamp' in csp_config
+    assert 'expire' in csp_config
+
+    timestamp = string_to_date(csp_config['timestamp'])
+    expire = string_to_date(csp_config['expire'])
+    delta = datetime.timedelta(seconds=cba_config.reporting_interval)
+
+    assert timestamp + delta == expire

--- a/tests/unit/test_local_csp.py
+++ b/tests/unit/test_local_csp.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Unit tests for the csp_billing_adapter.local_csp
+#
+
+import uuid
+from unittest import mock
+
+from pytest import raises
+
+from csp_billing_adapter.local_csp import (
+    get_account_info,
+    get_csp_name,
+    meter_billing
+)
+
+
+def test_meter_billing_ok(cba_config):
+    test_dimensions = {}
+    test_timestamp = "some_timestamp"
+    test_uuid = uuid.uuid4()
+    test_randval = 1
+
+    with mock.patch(
+        'csp_billing_adapter.local_csp.uuid.uuid4',
+        return_value=test_uuid
+    ):
+        with mock.patch(
+            'csp_billing_adapter.local_csp.randrange',
+            return_value=test_randval
+        ):
+            billing_id = meter_billing(
+                cba_config,
+                test_dimensions,
+                test_timestamp
+            )
+
+            assert billing_id == str(test_uuid.hex)
+
+
+def test_meter_billing_error(cba_config):
+    test_dimensions = {}
+    test_timestamp = "some_timestamp"
+    test_randval = 4
+
+    with mock.patch(
+        'csp_billing_adapter.local_csp.randrange',
+        return_value=test_randval
+    ):
+        with raises(Exception):
+            meter_billing(
+                cba_config,
+                test_dimensions,
+                test_timestamp
+            )
+
+
+def test_get_csp_name(cba_config):
+    # ensure this matches what is specified in local_csp module.
+    test_csp_name = 'local'
+
+    csp_name = get_csp_name(cba_config)
+    assert csp_name == test_csp_name
+
+
+def test_get_account_info(cba_config):
+    # ensure this matches what is specified in local_csp module.
+    test_account_info = {
+        'account_number': '123456789'
+    }
+
+    account_info = get_account_info(cba_config)
+    assert account_info == test_account_info

--- a/tests/unit/test_product_api.py
+++ b/tests/unit/test_product_api.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Unit tests for the csp_billing_adapter.product_api
+#
+
+from csp_billing_adapter.product_api import get_usage_data
+
+
+def test_memory_get_cache(cba_config):
+    possible_node_counts = [9, 10, 11, 25]
+
+    usage = get_usage_data(cba_config)
+
+    assert 'managed_node_count' in usage
+    assert usage['managed_node_count'] in possible_node_counts
+    assert 'reporting_time' in usage

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -72,7 +72,7 @@ def test_bad_get_date_delta_type_error():
     """Text exception raised for utils.get_date_delta"""
     with raises(TypeError, match="foo"):
         utils.get_date_delta(datetime.datetime(2023, 4, 20, 13, 8, 30),
-        'foo')
+                             'foo')
 
 
 def test_good_get_next_bill_time_hourly():


### PR DESCRIPTION
Add unit tests for the following modules in csp_billing_adapter:
  * product_api
  * csp_config
  * local_csp

Fix cba_config fixture to return a Config object rather than a dictionary.

Also fixed a flake8 complaint in tests/unit/test_utils.py