### PR TITLE
Refactor main() into multiple subroutines

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,5 +1,0 @@
-import csp_billing_adapter
-
-
-def test_adapter_version():
-    assert csp_billing_adapter.__version__ == "0.0.1"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,11 +55,11 @@ def data_dir(pytestconfig):
 
 
 @pytest.fixture
-def cba_config(data_dir, request):
+def cba_config_path(data_dir, request):
     """
-    Fixture returning a config dictionary loaded from the config
-    file specified by the config marker, defaulting to a known
-    good config if none is provided.
+    Fixture returning the path to the config file to load, as specified
+    by the config marker, defaulting to a known good config if none is
+    specified.
     """
     config_marker = request.node.get_closest_marker('config')
     if config_marker:
@@ -67,9 +67,16 @@ def cba_config(data_dir, request):
     else:
         config_file = 'config_good_average.yaml'
 
-    config_path = data_dir / config_file
+    return data_dir / config_file
 
-    with config_path.open() as conf_fp:
+
+@pytest.fixture
+def cba_config(cba_config_path):
+    """
+    Fixture returning a Config object loaded from the config
+    file specified by the cba_config_path fixture.
+    """
+    with cba_config_path.open() as conf_fp:
         config = yaml.safe_load(conf_fp)
 
     return Config(config)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,0 +1,277 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest import mock
+
+import pytest
+
+import csp_billing_adapter
+from csp_billing_adapter.adapter import (
+    event_loop_handler,
+    get_config,
+    get_plugin_manager,
+    initial_adapter_setup,
+    main as cba_main,
+    setup_logging
+)
+from csp_billing_adapter.utils import (
+    get_now,
+    string_to_date
+)
+
+
+def test_adapter_version():
+    """Verify the adapter version."""
+    assert csp_billing_adapter.__version__ == "0.0.1"
+
+
+def test_get_plugin_manager(cba_config):
+    """Verify that get_plugin_manager() works correctly."""
+    pm = get_plugin_manager()
+
+    # NOTE: we may need to explicitly pm.register(local_csp) here if
+    # we stop registering it in get_plugin_manager()
+
+    assert pm.hook.get_csp_name(config=cba_config) == "local"
+
+
+def test_setup_logging(cba_pm):
+    """Verify logging is being setup correctly."""
+    log = setup_logging(cba_pm.hook)
+
+    assert log.name == "CSPBillingAdapter"
+
+
+def test_get_config(cba_pm, cba_config, cba_config_path):
+    """Verify correct operation of get_config()."""
+    config = get_config(cba_config_path, cba_pm.hook)
+
+    assert config == cba_config
+
+
+def test_initial_adapter_setup(cba_pm, cba_config):
+    """
+    Verify that the initial_adapter_setup() works correctly using
+    in-memory plugins.
+    """
+    initial_adapter_setup(cba_pm.hook, cba_config)
+
+    cache = cba_pm.hook.get_cache(config=cba_config)
+    assert cache != {}
+
+    csp_config = cba_pm.hook.get_cache(config=cba_config)
+    assert csp_config != {}
+
+
+@mock.patch('csp_billing_adapter.local_csp.randrange')
+def test_event_loop_handler(mock_randrange, cba_pm, cba_config):
+    """Verify correct operation of event_loop_handler()."""
+    # ensure meter_billing will succeed
+    mock_randrange.return_value = 0
+
+    # setup the adapter environment similar to what is done
+    # inside the csp_billing_adapter.adapter.main()
+    log = setup_logging(cba_pm.hook)
+    assert log.name == ('CSPBillingAdapter')
+    initial_adapter_setup(cba_pm.hook, cba_config)
+
+    # validate the initial state of the cache
+    cache = cba_pm.hook.get_cache(config=cba_config)
+    assert cache != {}
+    assert cache['usage_records'] == []
+    assert cache['last_bill'] == {}
+
+    # validate the initial state of the csp_cache
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+    assert csp_config != {}
+    assert csp_config['billing_api_access_ok'] is True
+    assert 'timestamp' in csp_config
+    assert 'expire' in csp_config
+    assert csp_config['errors'] == []
+    assert 'usage' not in csp_config
+    assert 'last_billed' not in csp_config
+
+    #
+    # Startup/first iteration
+    #
+
+    # Simulate running the first iteration of the event loop after
+    # starting the csp-billing-adpater for the first time for a
+    # given config.
+    event_time = get_now()
+
+    # Patch the get_now() call to return the current time
+    # and simulate the first run of the event loop.
+    with mock.patch('csp_billing_adapter.adapter.get_now',
+                    return_value=event_time):
+        loop_event_time = event_loop_handler(cba_pm.hook, cba_config)
+        assert loop_event_time == event_time
+
+        # This run should have added a new usage_record, but
+        # not triggered any billing related updates to the cache.
+        cache = cba_pm.hook.get_cache(config=cba_config)
+        assert cache != {}
+        assert cache['usage_records'] != []
+        assert len(cache['usage_records']) == 1
+        assert cache['last_bill'] == {}
+
+        # Similarly the meter_billing() call should have succeeded
+        # not triggered the generation of a new bill.
+        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+        assert csp_config != {}
+        assert csp_config['billing_api_access_ok'] is True
+        assert csp_config['errors'] == []
+        assert 'usage' not in csp_config
+        assert 'last_billed' not in csp_config
+
+    #
+    # Advance to next_reporting_time
+    #
+
+    # Simulate running the event loop at the next reporting_time,
+    # which should just add a usage record entry, but not trigger
+    # any billing updates.
+    event_time = string_to_date(cache['next_reporting_time'])
+
+    with mock.patch('csp_billing_adapter.adapter.get_now',
+                    return_value=event_time):
+        loop_event_time = event_loop_handler(cba_pm.hook, cba_config)
+        assert loop_event_time == event_time
+
+        # This run should have added another usage_record, but
+        # not triggered any billing related updates to the cache.
+        cache = cba_pm.hook.get_cache(config=cba_config)
+        assert cache != {}
+        assert cache['usage_records'] != []
+        assert len(cache['usage_records']) == 2
+        assert cache['last_bill'] == {}
+
+        # Similarly the meter_billing() call should have succeeded
+        # not triggered the generation of a new bill.
+        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+        assert csp_config != {}
+        assert csp_config['billing_api_access_ok'] is True
+        assert csp_config['errors'] == []
+        assert 'usage' not in csp_config
+        assert 'last_billed' not in csp_config
+
+    #
+    # Advance to next_bill_time
+    #
+
+    # Simulate the event loop running at the next billing time,
+    # which should trigger billing related updates to the cache
+    # and csp_config data stores
+    event_time = string_to_date(cache['next_bill_time'])
+
+    with mock.patch('csp_billing_adapter.adapter.get_now',
+                    return_value=event_time):
+        loop_event_time = event_loop_handler(cba_pm.hook, cba_config)
+        assert loop_event_time == event_time
+
+        # This run should in the usage_records list being cleared
+        # in the case, along with the last_bill entry being updated
+        # to reflect the billing event that was triggered.
+        cache = cba_pm.hook.get_cache(config=cba_config)
+        assert cache != {}
+        assert cache['usage_records'] == []
+        assert cache['last_bill'] != {}
+        assert 'dimensions' in cache['last_bill']
+        assert 'record_id' in cache['last_bill']
+        assert 'metering_time' in cache['last_bill']
+
+        # The csp_config should now contain usage and last_billed
+        # entries matching the triggered billing event
+        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+        assert csp_config != {}
+        assert csp_config['billing_api_access_ok'] is True
+        assert csp_config['errors'] == []
+        assert 'usage' in csp_config
+        assert 'last_billed' in csp_config
+
+    #
+    # Advance to next_reporting_time with a meter_billing() failure
+    #
+
+    # Ensure we get a failure for meter_billing
+    mock_randrange.return_value = 4
+
+    # Simulate a failed meter_billing operation, which should result
+    # in an error being added to the errors list in the csp_config,
+    # and the billing_api_access_ok flag being cleared.
+    event_time = string_to_date(cache['next_reporting_time'])
+
+    with mock.patch('csp_billing_adapter.adapter.get_now',
+                    return_value=event_time):
+        loop_event_time = event_loop_handler(cba_pm.hook, cba_config)
+        assert loop_event_time == event_time
+
+        # A new usage record should have been added to the usage
+        # records list in the cache, and the last_bill entries should
+        # still be present.
+        cache = cba_pm.hook.get_cache(config=cba_config)
+        assert cache != {}
+        assert cache['usage_records'] != []
+        assert len(cache['usage_records']) == 1
+        assert cache['last_bill'] != {}
+        assert 'dimensions' in cache['last_bill']
+        assert 'record_id' in cache['last_bill']
+        assert 'metering_time' in cache['last_bill']
+
+        # An error should have been added to the errors list in the
+        # csp_config data store, and the billing_api_access_ok flag
+        # should be cleared to reflect that an error occurred.
+        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+        assert csp_config != {}
+        assert csp_config['billing_api_access_ok'] is False
+        assert csp_config['errors'] != []
+        assert 'usage' in csp_config
+        assert 'last_billed' in csp_config
+
+
+@mock.patch('csp_billing_adapter.adapter.get_plugin_manager')
+@mock.patch('csp_billing_adapter.adapter.get_config')
+def test_main(mock_get_config, mock_get_pm, cba_pm, cba_config):
+
+    mock_get_pm.return_value = cba_pm
+    mock_get_config.return_value = cba_config
+
+    # test catching Ctrl-C
+    with mock.patch(
+        'csp_billing_adapter.adapter.event_loop_handler',
+        side_effect=KeyboardInterrupt('Mock Ctrl-C')
+    ):
+        with pytest.raises(SystemExit) as e:
+            cba_main()
+        assert e.value.code == 0
+
+    # test catching SystemExit
+    with mock.patch(
+        'csp_billing_adapter.adapter.event_loop_handler',
+        side_effect=SystemExit(2)
+    ):
+        with pytest.raises(SystemExit) as e:
+            cba_main()
+        assert e.value.code == 2
+
+    # test catching Ctrl-C
+    with mock.patch(
+        'csp_billing_adapter.adapter.event_loop_handler',
+        side_effect=Exception('Mock Failure')
+    ):
+        with pytest.raises(SystemExit) as e:
+            cba_main()
+        assert e.value.code == 1

--- a/tests/unit/test_bill_utils.py
+++ b/tests/unit/test_bill_utils.py
@@ -288,7 +288,7 @@ def test_process_metering(cba_pm, cba_config):
 
     with mock.patch(
         'csp_billing_adapter.local_csp.randrange',
-        return_value=0  # meter_billing will succed
+        return_value=0  # meter_billing will succeed
     ):
         cache_data = cba_pm.hook.get_cache(config=cba_config)
         process_metering(


### PR DESCRIPTION
By refectoring the main() routine to call subroutines for various stages this allows easy unit testing of those stages.

Add unit tests for the new subroutines representing the various stages of the refactored main.

As part of implementing the test for get_config() the a new fixture, cba_config_path, was created to provide access to the marked config path, and the cba_config fixture has been re-worked to leverage it to determine the path to the file to load.

Also added a unit test for main itself to validate correct operation of exception handling.

Moved tests/test_adapter.py into tests/unit.