### PR TITLE
Restore 90% coverage requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,9 @@ testpaths = tests
 norecursedirs = data
 
 [coverage:report]
-fail_under = 85
+fail_under = 90
+show_missing = True
+
 
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
Also add show_missing=True to setup.cfg options for pytext coverage reporting so that it shows the line numbers for the statements not covered.