### PR TITLE
Only load testing support plugins in unit tests

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -42,11 +42,10 @@ from csp_billing_adapter.utils import (
     string_to_date
 )
 from csp_billing_adapter.bill_utils import process_metering
-from csp_billing_adapter import hookspecs
-from csp_billing_adapter import csp_hookspecs
-from csp_billing_adapter import storage_hookspecs
 from csp_billing_adapter import (
-    local_csp,
+    csp_hookspecs,
+    hookspecs,
+    storage_hookspecs
 )
 
 DEFAULT_CONFIG_PATH = '/etc/csp_billing_adapter/config.yaml'
@@ -66,7 +65,6 @@ def get_plugin_manager() -> pluggy.PluginManager:
     pm.add_hookspecs(csp_hookspecs)
     pm.add_hookspecs(storage_hookspecs)
     pm.load_setuptools_entrypoints('csp_billing_adapter')
-    pm.register(local_csp)
     return pm
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,9 +20,10 @@ import yaml
 import pytest
 
 from csp_billing_adapter import (
-    product_api,
+    local_csp,
     memory_cache,
-    memory_csp_config
+    memory_csp_config,
+    product_api
 )
 
 from csp_billing_adapter.adapter import get_plugin_manager
@@ -95,6 +96,7 @@ def cba_pm(cba_config):
     pm.register(product_api)
     pm.register(memory_cache)
     pm.register(memory_csp_config)
+    pm.register(local_csp)
 
     # reset the in-memory cache to empty
     pm.hook.save_cache(config=cba_config, cache=dict())

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -19,6 +19,12 @@ from unittest import mock
 import pytest
 
 import csp_billing_adapter
+from csp_billing_adapter import (
+    local_csp,
+    memory_cache,
+    memory_csp_config,
+    product_api
+)
 from csp_billing_adapter.adapter import (
     event_loop_handler,
     get_config,
@@ -45,8 +51,15 @@ def test_get_plugin_manager(cba_config):
     """Verify that get_plugin_manager() works correctly."""
     pm = get_plugin_manager()
 
-    # NOTE: we may need to explicitly pm.register(local_csp) here if
-    # we stop registering it in get_plugin_manager()
+    # the testing plugins shouldn't be registered
+    assert pm.is_registered(local_csp) is False
+    assert pm.is_registered(memory_cache) is False
+    assert pm.is_registered(memory_csp_config) is False
+    assert pm.is_registered(product_api) is False
+
+    # register the local_csp plugin so that we can call a
+    # hook implementation that it provides
+    pm.register(local_csp)
 
     assert pm.hook.get_csp_name(config=cba_config) == "local"
 


### PR DESCRIPTION
Move the registration of the last of the testing support plugins, local_csp, to the cba_pm fixture in tests/unit/conftest.py.

Also validate in the get_plugin_manager() testing that none of the testing plugins are loaded by default anymore.

Implements: #62