### PR TITLE
Add additional logging to core paths

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import logging
 import pathlib
 import yaml
 
@@ -105,3 +106,8 @@ def cba_pm(cba_config):
     pm.hook.save_csp_config(config=cba_config, csp_config=dict())
 
     return pm
+
+
+@pytest.fixture
+def cba_log():
+    return logging.getLogger('CSPBillingAdapter')


### PR DESCRIPTION
Add info and debug logging messages to most of the core functions that can be used to see key details (info level) and trace what the code is doing (debug level).

Add log parameter to the core routines in csp_billing_adapter.adapter that are called, as part of the main() entry point, after logging has been setup.

Also renamed some variables to improve clarity of code.

Implements: #70