### PR TITLE
Initial exception handling enhancements

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -108,12 +108,26 @@ def initial_adapter_setup(
     hook.setup_adapter(config=config)
 
     log.debug("Initializing the csp_config")
-    csp_config = hook.get_csp_config(config=config)
+    try:
+        csp_config = hook.get_csp_config(config=config)
+    except Exception as e:
+        log.warning(
+            "Failed to retrieve existing CSP config: %s",
+            str(e)
+        )
+        csp_config = {}
     if not csp_config:
         create_csp_config(hook, config)
 
     log.debug("Initializing the cache")
-    cache = hook.get_cache(config=config)
+    try:
+        cache = hook.get_cache(config=config)
+    except Exception as e:
+        log.warning(
+            "Failed to retrieve existing cache: %s",
+            str(e)
+        )
+        cache = {}
     if not cache:
         create_cache(hook, config)
 
@@ -128,27 +142,56 @@ def event_loop_handler(
     """Perform the event loop processing actions."""
     log.info('Starting event loop processing')
 
-    usage = hook.get_usage_data(config=config)
-    log.debug('Retrieved usage data: %s', usage)
+    try:
+        usage = hook.get_usage_data(config=config)
+    except Exception as exc:
+        log.warning("Failed to retrieve usage data: %s", str(exc))
+        now = get_now()
+        hook.update_csp_config(
+            config=config,
+            csp_config={
+                'timestamp': date_to_string(now),
+                'billing_api_access_ok': False,
+                'errors': [
+                    f'Usage data retrieval failed: {exc}'
+                ]
+            },
+            replace=False
+        )
+        # NOTE:
+        # If this happens during initial deployment timeframe, failing
+        # to retrieve usage data here could simple mean that there is
+        # nothing to bill for yet so not proceeding to metering makes
+        # sense.
+        # If this occurs for an existing deployment, with valid usage
+        # records waiting to be billed, continuing on to metering is
+        # worth considering.
+        # However, doing so will currently result in the error state
+        # that was saved in the csp_config being lost, as it would be
+        # overwritten with a success state, or a different error.
 
-    add_usage_record(hook, config, usage)
+    else:
+        log.debug('Retrieved usage data: %s', usage)
 
-    cache = hook.get_cache(config=config)
-    now = get_now()
+        add_usage_record(hook, config, usage)
 
-    log.debug(
-        "Now: %s, Next Reporting Time: %s, Next Bill Time: %s",
-        date_to_string(now),
-        cache['next_reporting_time'],
-        cache['next_bill_time']
-    )
+        # handle metering/billing updates
+        cache = hook.get_cache(config=config)
+        now = get_now()
 
-    if now >= string_to_date(cache['next_bill_time']):
-        log.info('Attempt a billing cycle update')
-        process_metering(config, cache, hook)
-    elif now >= string_to_date(cache['next_reporting_time']):
-        log.info('Attempt a reporting cycle update')
-        process_metering(config, cache, hook, empty_metering=True)
+        log.debug(
+            "Now: %s, Next Reporting Time: %s, Next Bill Time: %s",
+            date_to_string(now),
+            cache['next_reporting_time'],
+            cache['next_bill_time']
+        )
+
+        if now >= string_to_date(cache['next_bill_time']):
+            log.info('Attempt a billing cycle update')
+            process_metering(config, cache, hook)
+        elif now >= string_to_date(cache['next_reporting_time']):
+            log.info('Attempt a reporting cycle update')
+            process_metering(config, cache, hook, empty_metering=True)
 
     log.info('Finishing event loop processing')
     return now

--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -170,28 +170,30 @@ def event_loop_handler(
         # that was saved in the csp_config being lost, as it would be
         # overwritten with a success state, or a different error.
 
-    else:
-        log.debug('Retrieved usage data: %s', usage)
+        log.info('Finishing event loop processing - get_usage_data() error')
+        return now
 
-        add_usage_record(hook, config, usage)
+    log.debug('Retrieved usage data: %s', usage)
 
-        # handle metering/billing updates
-        cache = hook.get_cache(config=config)
-        now = get_now()
+    add_usage_record(hook, config, usage)
 
-        log.debug(
-            "Now: %s, Next Reporting Time: %s, Next Bill Time: %s",
-            date_to_string(now),
-            cache['next_reporting_time'],
-            cache['next_bill_time']
-        )
+    # handle metering/billing updates
+    cache = hook.get_cache(config=config)
+    now = get_now()
 
-        if now >= string_to_date(cache['next_bill_time']):
-            log.info('Attempt a billing cycle update')
-            process_metering(config, cache, hook)
-        elif now >= string_to_date(cache['next_reporting_time']):
-            log.info('Attempt a reporting cycle update')
-            process_metering(config, cache, hook, empty_metering=True)
+    log.debug(
+        "Now: %s, Next Reporting Time: %s, Next Bill Time: %s",
+        date_to_string(now),
+        cache['next_reporting_time'],
+        cache['next_bill_time']
+    )
+
+    if now >= string_to_date(cache['next_bill_time']):
+        log.info('Attempt a billing cycle update')
+        process_metering(config, cache, hook)
+    elif now >= string_to_date(cache['next_reporting_time']):
+        log.info('Attempt a reporting cycle update')
+        process_metering(config, cache, hook, empty_metering=True)
 
     log.info('Finishing event loop processing')
     return now

--- a/csp_billing_adapter/csp_config.py
+++ b/csp_billing_adapter/csp_config.py
@@ -23,6 +23,9 @@ low-level CSP config management operations.
 import logging
 
 from csp_billing_adapter.config import Config
+from csp_billing_adapter.exceptions import (
+    FailedToSaveCSPConfigError
+)
 from csp_billing_adapter.utils import get_now, date_to_string, get_date_delta
 
 log = logging.getLogger('CSPBillingAdapter')
@@ -52,6 +55,13 @@ def create_csp_config(
         'errors': []
     }
 
-    hook.save_csp_config(config=config, csp_config=csp_config)
+    try:
+        hook.save_csp_config(config=config, csp_config=csp_config)
+    except Exception as exc:
+        # raise an application specific exception that will be
+        # caught by the event loop in main() and cause an exit
+        # with a failure status.
+        log.error("Unable to save CSP config: %s", str(exc))
+        raise FailedToSaveCSPConfigError(str(exc)) from exc
 
     log.debug("CSP config initialized with: %s", csp_config)

--- a/csp_billing_adapter/exceptions.py
+++ b/csp_billing_adapter/exceptions.py
@@ -41,3 +41,11 @@ class NoMatchingVolumeDimensionError(CSPBillingAdapterException):
 
     def __str__(self):
         return self.msg
+
+
+class FailedToSaveCSPConfigError(CSPBillingAdapterException):
+    """Exception raised when csp_config save/update fails."""
+
+
+class FailedToSaveCacheError(CSPBillingAdapterException):
+    """Exception raised when cache save/update fails."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -87,9 +87,9 @@ def cba_config(cba_config_path):
 @pytest.fixture
 def cba_pm(cba_config):
     """
-    Fixture returning an initialized plugin manager instance, based
-    on supplied config. Also needs to reset the in-memory cache and
-    csp_config to empty to simulate a fresh start.
+    Fixture returning an initialized plugin manager instance, with
+    all the relevant testing plugins registered and the in-memory
+    cache and csp_config reset as empty to simulate a fresh start.
     """
     pm = get_plugin_manager()
 


### PR DESCRIPTION
Enhance the exception handling support for code paths related to the the initial start up of the CSP Billing Adapter.

  * failures retrieving existing data from data stores that may not exist yet are handled gracefully, without the main event loop seeing them.

  * failures creating/initializing key data stores are reported and an exception is raised that will cause the main event loop to fail.

  * failures to retrieve usage data, which may not have been published yet, are handled gracefully, skipping follow on metering attempt for now, and without the main event loop seeing them. NOTE: If this issue persists this would lead to metering not being performed, but performing metering would overwrite the error that was reported for the get_usage_data() operation.

Add tests to exercise and validate the new exception handling code.

Remove stale code from test_event_loop_handler() relating to log var.

Re-word the cba_pm docstring message to better reflect what it does.

Implements: #70