### PR TITLE
Update unittests to match recent bumpversion run.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ tag = True
 
 [bumpversion:file:csp-billing-adapter.spec]
 
+[bumpversion:file:tests/unit/test_adapter.py]
+
 [tool:pytest]
 testpaths = tests
 norecursedirs = data

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -44,7 +44,7 @@ from csp_billing_adapter.utils import (
 
 def test_adapter_version():
     """Verify the adapter version."""
-    assert csp_billing_adapter.__version__ == "0.0.1"
+    assert csp_billing_adapter.__version__ == "0.0.2"
 
 
 def test_get_plugin_manager(cba_config):


### PR DESCRIPTION
Also add the relevant unittest file to list of files that bumpversion updates.