### PR TITLE
Add base_product info to csp_config

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -159,6 +159,7 @@ def event_loop_handler(
 
     if usage:
         add_usage_record(usage, cache)
+        csp_config['base_product'] = usage.get('base_product', '')
 
     log.debug(
         "Now: %s, Next Reporting Time: %s, Next Bill Time: %s",

--- a/csp_billing_adapter/product_api.py
+++ b/csp_billing_adapter/product_api.py
@@ -42,7 +42,8 @@ def get_usage_data(config: Config) -> dict:
 
     usage = {
         'managed_node_count': quantity,
-        'reporting_time': date_to_string(get_now())
+        'reporting_time': date_to_string(get_now()),
+        'base_product': 'cpe:/o:suse:product:v1.2.3'
     }
 
     log.info("Simulated Usage data: %s", usage)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -188,6 +188,7 @@ def test_event_loop_handler(mock_randrange, cba_pm, cba_config, cba_log):
     assert 'usage' not in csp_config
     assert 'last_billed' not in csp_config
     assert csp_config['timestamp'] == date_to_string(event_time)
+    assert csp_config['base_product'] == 'cpe:/o:suse:product:v1.2.3'
 
     #
     # Advance to next_reporting_time


### PR DESCRIPTION
Each time a usage record is retrieved. This keeps the support config up-to-date with latest product version.