### PR TITLE
Sleep for the remainder of a query_interval.

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -137,12 +137,12 @@ def initial_adapter_setup(
 
 
 def event_loop_handler(
+    now: datetime.datetime,
     hook,
     config: Config,
     log: logging.Logger
-) -> datetime.datetime:
+) -> None:
     """Perform the event loop processing actions."""
-    now = get_now()
     log.info('Starting event loop processing')
 
     try:
@@ -197,7 +197,6 @@ def event_loop_handler(
         process_metering(config, cache, hook, empty_metering=True)
 
     log.info('Finishing event loop processing')
-    return now
 
 
 def main() -> None:
@@ -242,10 +241,13 @@ def main() -> None:
         time.sleep(config.query_interval)  # wait 1 cycle for usage data
 
         while True:
-            start = event_loop_handler(pm.hook, config, log)
+            start = get_now()
+            event_loop_handler(start, pm.hook, config, log)
             log.info("Processed event loop at %s", date_to_string(start))
 
-            query_interval_remainder = (get_now() - start).total_seconds()
+            query_interval_remainder = (
+                config.query_interval - (get_now() - start).total_seconds()
+            )
             log.debug("Sleeping for %g seconds", query_interval_remainder)
             time.sleep(query_interval_remainder)
     except KeyboardInterrupt:

--- a/csp_billing_adapter/config.py
+++ b/csp_billing_adapter/config.py
@@ -50,7 +50,7 @@ class Config(dict):
             else:
                 setattr(self, key, self.parse_value(val))
 
-        log.debug("Config: %s %s", self)
+        log.debug("Config: %s", self)
 
     def parse_value(self, item):
         """recursive evaluation if item is a dict"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -110,4 +110,7 @@ def cba_pm(cba_config):
 
 @pytest.fixture
 def cba_log():
-    return logging.getLogger('CSPBillingAdapter')
+    log = logging.getLogger('CSPBillingAdapter')
+    log.setLevel(logging.DEBUG)
+
+    return log

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -161,29 +161,24 @@ def test_event_loop_handler(mock_randrange, cba_pm, cba_config, cba_log):
     # given config.
     event_time = get_now()
 
-    # Patch the get_now() call to return the current time
-    # and simulate the first run of the event loop.
-    with mock.patch('csp_billing_adapter.adapter.get_now',
-                    return_value=event_time):
-        loop_event_time = event_loop_handler(cba_pm.hook, cba_config, cba_log)
-        assert loop_event_time == event_time
+    event_loop_handler(event_time, cba_pm.hook, cba_config, cba_log)
 
-        # This run should have added a new usage_record, but
-        # not triggered any billing related updates to the cache.
-        cache = cba_pm.hook.get_cache(config=cba_config)
-        assert cache != {}
-        assert cache['usage_records'] != []
-        assert len(cache['usage_records']) == 1
-        assert cache['last_bill'] == {}
+    # This run should have added a new usage_record, but
+    # not triggered any billing related updates to the cache.
+    cache = cba_pm.hook.get_cache(config=cba_config)
+    assert cache != {}
+    assert cache['usage_records'] != []
+    assert len(cache['usage_records']) == 1
+    assert cache['last_bill'] == {}
 
-        # Similarly the meter_billing() call should have succeeded
-        # not triggered the generation of a new bill.
-        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
-        assert csp_config != {}
-        assert csp_config['billing_api_access_ok'] is True
-        assert csp_config['errors'] == []
-        assert 'usage' not in csp_config
-        assert 'last_billed' not in csp_config
+    # Similarly the meter_billing() call should have succeeded
+    # not triggered the generation of a new bill.
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+    assert csp_config != {}
+    assert csp_config['billing_api_access_ok'] is True
+    assert csp_config['errors'] == []
+    assert 'usage' not in csp_config
+    assert 'last_billed' not in csp_config
 
     #
     # Advance to next_reporting_time
@@ -194,27 +189,24 @@ def test_event_loop_handler(mock_randrange, cba_pm, cba_config, cba_log):
     # any billing updates.
     event_time = string_to_date(cache['next_reporting_time'])
 
-    with mock.patch('csp_billing_adapter.adapter.get_now',
-                    return_value=event_time):
-        loop_event_time = event_loop_handler(cba_pm.hook, cba_config, cba_log)
-        assert loop_event_time == event_time
+    event_loop_handler(event_time, cba_pm.hook, cba_config, cba_log)
 
-        # This run should have added another usage_record, but
-        # not triggered any billing related updates to the cache.
-        cache = cba_pm.hook.get_cache(config=cba_config)
-        assert cache != {}
-        assert cache['usage_records'] != []
-        assert len(cache['usage_records']) == 2
-        assert cache['last_bill'] == {}
+    # This run should have added another usage_record, but
+    # not triggered any billing related updates to the cache.
+    cache = cba_pm.hook.get_cache(config=cba_config)
+    assert cache != {}
+    assert cache['usage_records'] != []
+    assert len(cache['usage_records']) == 2
+    assert cache['last_bill'] == {}
 
-        # Similarly the meter_billing() call should have succeeded
-        # not triggered the generation of a new bill.
-        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
-        assert csp_config != {}
-        assert csp_config['billing_api_access_ok'] is True
-        assert csp_config['errors'] == []
-        assert 'usage' not in csp_config
-        assert 'last_billed' not in csp_config
+    # Similarly the meter_billing() call should have succeeded
+    # not triggered the generation of a new bill.
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+    assert csp_config != {}
+    assert csp_config['billing_api_access_ok'] is True
+    assert csp_config['errors'] == []
+    assert 'usage' not in csp_config
+    assert 'last_billed' not in csp_config
 
     #
     # Advance to next_bill_time
@@ -225,30 +217,27 @@ def test_event_loop_handler(mock_randrange, cba_pm, cba_config, cba_log):
     # and csp_config data stores
     event_time = string_to_date(cache['next_bill_time'])
 
-    with mock.patch('csp_billing_adapter.adapter.get_now',
-                    return_value=event_time):
-        loop_event_time = event_loop_handler(cba_pm.hook, cba_config, cba_log)
-        assert loop_event_time == event_time
+    event_loop_handler(event_time, cba_pm.hook, cba_config, cba_log)
 
-        # This run should in the usage_records list being cleared
-        # in the case, along with the last_bill entry being updated
-        # to reflect the billing event that was triggered.
-        cache = cba_pm.hook.get_cache(config=cba_config)
-        assert cache != {}
-        assert cache['usage_records'] == []
-        assert cache['last_bill'] != {}
-        assert 'dimensions' in cache['last_bill']
-        assert 'record_id' in cache['last_bill']
-        assert 'metering_time' in cache['last_bill']
+    # This run should in the usage_records list being cleared
+    # in the case, along with the last_bill entry being updated
+    # to reflect the billing event that was triggered.
+    cache = cba_pm.hook.get_cache(config=cba_config)
+    assert cache != {}
+    assert cache['usage_records'] == []
+    assert cache['last_bill'] != {}
+    assert 'dimensions' in cache['last_bill']
+    assert 'record_id' in cache['last_bill']
+    assert 'metering_time' in cache['last_bill']
 
-        # The csp_config should now contain usage and last_billed
-        # entries matching the triggered billing event
-        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
-        assert csp_config != {}
-        assert csp_config['billing_api_access_ok'] is True
-        assert csp_config['errors'] == []
-        assert 'usage' in csp_config
-        assert 'last_billed' in csp_config
+    # The csp_config should now contain usage and last_billed
+    # entries matching the triggered billing event
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+    assert csp_config != {}
+    assert csp_config['billing_api_access_ok'] is True
+    assert csp_config['errors'] == []
+    assert 'usage' in csp_config
+    assert 'last_billed' in csp_config
 
     #
     # Advance to next_reporting_time with a meter_billing() failure
@@ -262,32 +251,29 @@ def test_event_loop_handler(mock_randrange, cba_pm, cba_config, cba_log):
     # and the billing_api_access_ok flag being cleared.
     event_time = string_to_date(cache['next_reporting_time'])
 
-    with mock.patch('csp_billing_adapter.adapter.get_now',
-                    return_value=event_time):
-        loop_event_time = event_loop_handler(cba_pm.hook, cba_config, cba_log)
-        assert loop_event_time == event_time
+    event_loop_handler(event_time, cba_pm.hook, cba_config, cba_log)
 
-        # A new usage record should have been added to the usage
-        # records list in the cache, and the last_bill entries should
-        # still be present.
-        cache = cba_pm.hook.get_cache(config=cba_config)
-        assert cache != {}
-        assert cache['usage_records'] != []
-        assert len(cache['usage_records']) == 1
-        assert cache['last_bill'] != {}
-        assert 'dimensions' in cache['last_bill']
-        assert 'record_id' in cache['last_bill']
-        assert 'metering_time' in cache['last_bill']
+    # A new usage record should have been added to the usage
+    # records list in the cache, and the last_bill entries should
+    # still be present.
+    cache = cba_pm.hook.get_cache(config=cba_config)
+    assert cache != {}
+    assert cache['usage_records'] != []
+    assert len(cache['usage_records']) == 1
+    assert cache['last_bill'] != {}
+    assert 'dimensions' in cache['last_bill']
+    assert 'record_id' in cache['last_bill']
+    assert 'metering_time' in cache['last_bill']
 
-        # An error should have been added to the errors list in the
-        # csp_config data store, and the billing_api_access_ok flag
-        # should be cleared to reflect that an error occurred.
-        csp_config = cba_pm.hook.get_csp_config(config=cba_config)
-        assert csp_config != {}
-        assert csp_config['billing_api_access_ok'] is False
-        assert csp_config['errors'] != []
-        assert 'usage' in csp_config
-        assert 'last_billed' in csp_config
+    # An error should have been added to the errors list in the
+    # csp_config data store, and the billing_api_access_ok flag
+    # should be cleared to reflect that an error occurred.
+    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+    assert csp_config != {}
+    assert csp_config['billing_api_access_ok'] is False
+    assert csp_config['errors'] != []
+    assert 'usage' in csp_config
+    assert 'last_billed' in csp_config
 
 
 def test_event_loop_handler_usage_data_error(
@@ -298,32 +284,27 @@ def test_event_loop_handler_usage_data_error(
 ):
     event_time = get_now()
 
-    with mock.patch('csp_billing_adapter.adapter.get_now',
-                    return_value=event_time):
-
-        error = Exception("Simulated failed get_usage_data() Error")
-        with mock.patch.object(
+    error = Exception("Simulated failed get_usage_data() Error")
+    with mock.patch.object(
+        cba_pm.hook,
+        'get_usage_data',
+        side_effect=error
+    ):
+        event_loop_handler(
+            event_time,
             cba_pm.hook,
-            'get_usage_data',
-            side_effect=error
-        ):
-            loop_event_time = event_loop_handler(
-                cba_pm.hook,
-                cba_config,
-                cba_log
-            )
+            cba_config,
+            cba_log
+        )
 
-            # event loop handler should return expected event time
-            assert loop_event_time == event_time
+        # simulated error's message should be in the log
+        assert str(error) in caplog.text
 
-            # simulated error's message should be in the log
-            assert str(error) in caplog.text
+        # get_usage_data() succeeded message should not be in log
+        assert 'Retrieved usage data: ' not in caplog.text
 
-            # get_usage_data() succeeded message should not be in log
-            assert 'Retrieved usage data: ' not in caplog.text
-
-            # end of event loop processing message should be in log
-            assert 'Finishing event loop processing' in caplog.text
+        # end of event loop processing message should be in log
+        assert 'Finishing event loop processing' in caplog.text
 
 
 @mock.patch('csp_billing_adapter.local_csp.randrange')
@@ -420,7 +401,7 @@ def test_main_sleep(
     # and debug level is enabled for the cba_log fixture
     expected_log_msg = (
         "Sleeping for %g seconds" % (
-            (now - event_time).total_seconds()
+            cba_config.query_interval - (now - event_time).total_seconds()
         )
     )
 
@@ -428,8 +409,11 @@ def test_main_sleep(
     mock_get_pm.return_value = cba_pm
     mock_setup_logging.return_value = cba_log
     mock_get_config.return_value = cba_config
-    mock_event_loop_handler.return_value = event_time
-    mock_get_now.return_value = now
+    mock_event_loop_handler.return_value = None
+
+    # get_now() is called at the start of the main loop, and again to
+    # get the current time to determine how much time to sleep for.
+    mock_get_now.side_effect = [event_time, now]
 
     # time.sleep is called before the main loop runs, which needs to
     # succeed, but the next call, at the end of the main loop should


### PR DESCRIPTION
By factoring in how long the event_loop_handler() processing takes when calculating the amount of time to sleep for, the drift effect will be minimised.

Enable debug level message logging for the cba_log fixture.

Also fixed typo in Config.__init__() log message format that showed up when debug level logging was enabled.

Fixes: #84