### PR TITLE
At initial startup on first deploy no data exists

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -111,7 +111,7 @@ def initial_adapter_setup(
     try:
         csp_config = hook.get_csp_config(config=config)
     except Exception as e:
-        log.warning(
+        log.debug(
             "Failed to retrieve existing CSP config: %s",
             str(e)
         )
@@ -124,7 +124,7 @@ def initial_adapter_setup(
     try:
         cache = hook.get_cache(config=config)
     except Exception as e:
-        log.warning(
+        log.debug(
             "Failed to retrieve existing cache: %s",
             str(e)
         )


### PR DESCRIPTION
Thus the errors should be debug level. If the adapter is restarted or re-deployed on a cluster where it was already running then the data exists. Both are valid workflows.