### PR TITLE
Fix retry_on_exception() call parameters

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -295,7 +295,7 @@ def main() -> None:
                     timestamp=csp_config['timestamp'],
                     dry_run=True
                 ),
-                log,
+                logger=log,
                 func_name="hook.meter_billing"
             )
         except AttributeError as attr_error:


### PR DESCRIPTION
Add missing logger= prefix when passing the log paramter to the retry_on_exception() routine.

Fixes: #99