### PR TITLE
Split up create_csp_config into components

### DIFF
--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -34,7 +34,8 @@ from csp_billing_adapter.adapter import (
     setup_logging
 )
 from csp_billing_adapter.exceptions import (
-    NoMatchingVolumeDimensionError
+    NoMatchingVolumeDimensionError,
+    FailedToSaveCSPConfigError
 )
 from csp_billing_adapter.utils import (
     get_now,
@@ -125,12 +126,18 @@ def test_initial_adapter_setup_csp_config_errors(
         'get_csp_config',
         side_effect=error
     ):
-        cache, csp_config, = initial_adapter_setup(
+        # test save_csp_config() hook raises an exception
+        with mock.patch.object(
             cba_pm.hook,
-            cba_config,
-            cba_log
-        )
-        assert str(error) in caplog.text
+            'save_csp_config',
+            side_effect=error
+        ):
+            with pytest.raises(FailedToSaveCSPConfigError):
+                initial_adapter_setup(
+                    cba_pm.hook,
+                    cba_config,
+                    cba_log
+                )
 
 
 @mock.patch('csp_billing_adapter.adapter.time.sleep')

--- a/tests/unit/test_bill_utils.py
+++ b/tests/unit/test_bill_utils.py
@@ -442,8 +442,8 @@ def test_process_metering(mock_sleep, cba_pm, cba_config):
     test_csp_config = cba_pm.hook.get_csp_config(config=cba_config)
     assert test_csp_config == {}
 
-    create_csp_config(cba_pm.hook, cba_config)
-    test_csp_config = cba_pm.hook.get_csp_config(config=cba_config)
+    account_info = {'cusomter': 'data'}
+    test_csp_config = create_csp_config(cba_config, account_info)
 
     assert 'billing_api_access_ok' in test_csp_config
     assert test_csp_config['billing_api_access_ok'] is True
@@ -565,9 +565,9 @@ def test_process_metering_no_matching_dimensions(cba_pm, cba_config):
     test_csp_config = cba_pm.hook.get_csp_config(config=cba_config)
     assert test_csp_config == {}
 
-    create_csp_config(cba_pm.hook, cba_config)
+    account_info = {'cusomter': 'data'}
+    test_csp_config = create_csp_config(cba_config, account_info)
 
-    test_csp_config = cba_pm.hook.get_csp_config(config=cba_config)
     assert 'billing_api_access_ok' in test_csp_config
     assert test_csp_config['billing_api_access_ok'] is True
     assert 'timestamp' in test_csp_config

--- a/tests/unit/test_csp_config.py
+++ b/tests/unit/test_csp_config.py
@@ -19,56 +19,24 @@
 #
 
 import datetime
-from unittest import mock
-
-from pytest import raises
 
 from csp_billing_adapter.csp_config import create_csp_config
-from csp_billing_adapter.exceptions import (
-    FailedToSaveCSPConfigError
-)
 from csp_billing_adapter.utils import string_to_date
 
 
-def test_create_csp_config(cba_pm, cba_config):
-    # csp_config should initially be empty
-    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
+def test_create_csp_config(cba_config):
+    account_info = {'name': 'account1', 'id': '1234567890'}
+    new_csp_config = create_csp_config(cba_config, account_info)
 
-    new_csp_config = create_csp_config(cba_pm.hook, cba_config)
+    assert 'billing_api_access_ok' in new_csp_config
+    assert new_csp_config['billing_api_access_ok'] is True
+    assert 'timestamp' in new_csp_config
+    assert 'customer_csp_data' in new_csp_config
+    assert new_csp_config['customer_csp_data'] == account_info
+    assert 'expire' in new_csp_config
 
-    csp_config = cba_pm.hook.get_csp_config(config=cba_config)
-
-    assert 'billing_api_access_ok' in csp_config
-    assert csp_config['billing_api_access_ok'] is True
-    assert 'timestamp' in csp_config
-    assert 'expire' in csp_config
-
-    assert new_csp_config == csp_config
-
-    timestamp = string_to_date(csp_config['timestamp'])
-    expire = string_to_date(csp_config['expire'])
+    timestamp = string_to_date(new_csp_config['timestamp'])
+    expire = string_to_date(new_csp_config['expire'])
     delta = datetime.timedelta(seconds=cba_config.reporting_interval)
 
     assert timestamp + delta == expire
-
-
-@mock.patch('csp_billing_adapter.utils.time.sleep')
-def test_create_csp_config_save_exception(
-    mock_sleep,
-    cba_pm,
-    cba_config,
-    caplog
-):
-    # csp_config should initially be empty
-    assert cba_pm.hook.get_csp_config(config=cba_config) == {}
-
-    # simulate save_csp_cache() hook raising an exception
-    error = Exception("Simulated save_csp_cache() hook Exception")
-    with mock.patch.object(
-        cba_pm.hook,
-        'save_csp_config',
-        side_effect=error
-    ):
-        with raises(FailedToSaveCSPConfigError):
-            create_csp_config(cba_pm.hook, cba_config)
-        assert str(error) in caplog.text


### PR DESCRIPTION
The function only creates a new dict and takes account info as a arg. The csp-config is saved to datastore separately from calling scope.