### PR TITLE
Add config version check at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,7 @@ the customer through UI.
     - "Unexpected error: ..."
 - If there is an expected but unrecoverable error an error will be added then adapter will crash:
     - "CSP Billing Adapter error: ..."
+- If the config file is missing the version attribute the adapter will raise an error:
+    - "Invalid config file. Missing 'version' attribute."
+- If the config file has an incompatible version the adapter will raise an error that starts with:
+    - "Incompatible config file. Found version: ..."

--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -52,6 +52,8 @@ from csp_billing_adapter import (
 )
 
 DEFAULT_CONFIG_PATH = '/etc/csp_billing_adapter/config.yaml'
+CONFIG_MIN = '0.0.0'
+CONFIG_MAX = '1.0.0'
 
 config_path = os.environ.get('CSP_ADAPTER_CONFIG_FILE') or DEFAULT_CONFIG_PATH
 
@@ -96,6 +98,20 @@ def get_config(
         config_path,
         hook
     )
+
+    try:
+        version = config['version']
+    except KeyError:
+        raise CSPBillingAdapterException(
+            'Invalid config file. Missing "version" attribute.'
+        )
+
+    if not (CONFIG_MIN <= version < CONFIG_MAX):
+        raise CSPBillingAdapterException(
+            'Incompatible config file. Found version: {version}, '
+            'expecting version between {CONFIG_MIN} '
+            'and {CONFIG_MAX}.'
+        )
 
     # If there is anything sensitive in config we may want to add
     # a __str__() method that sanitizes it.

--- a/tests/data/config_bad.yaml
+++ b/tests/data/config_bad.yaml
@@ -26,4 +26,4 @@ usage_metrics:
       min: 1001
     min_consumption: 5
     usage_aggregation: average
-version: 1.1.1
+version: 0.1.1

--- a/tests/data/config_bad_version.yaml
+++ b/tests/data/config_bad_version.yaml
@@ -8,21 +8,22 @@ usage_metrics:
     consumption_reporting: volume
     dimensions:
     - dimension: tier_1
-      min: 0
       max: 15
+      min: 0
     - dimension: tier_2
-      min: 16
       max: 50
+      min: 16
     - dimension: tier_3
-      min: 51
       max: 100
+      min: 51
     - dimension: tier_4
-      min: 101
       max: 250
+      min: 101
     - dimension: tier_5
+      max: 1000
       min: 251
-      max: 500
-    # missing a final dimension for 501+
+    - dimension: tier_6
+      min: 1001
     min_consumption: 5
     usage_aggregation: average
-version: 0.1.1
+version: 1.1.1

--- a/tests/data/config_dimensions_gap.yaml
+++ b/tests/data/config_dimensions_gap.yaml
@@ -27,4 +27,4 @@ usage_metrics:
       min: 1001
     min_consumption: 5
     usage_aggregation: average
-version: 1.1.1
+version: 0.1.1

--- a/tests/data/config_good_average.yaml
+++ b/tests/data/config_good_average.yaml
@@ -26,4 +26,4 @@ usage_metrics:
       min: 1001
     min_consumption: 5
     usage_aggregation: average
-version: 1.1.1
+version: 0.1.1

--- a/tests/data/config_good_maximum.yaml
+++ b/tests/data/config_good_maximum.yaml
@@ -26,4 +26,4 @@ usage_metrics:
       min: 1001
     min_consumption: 5
     usage_aggregation: maximum
-version: 1.1.1
+version: 0.1.1

--- a/tests/data/config_missing_version.yaml
+++ b/tests/data/config_missing_version.yaml
@@ -8,21 +8,21 @@ usage_metrics:
     consumption_reporting: volume
     dimensions:
     - dimension: tier_1
-      min: 0
       max: 15
+      min: 0
     - dimension: tier_2
-      min: 16
       max: 50
+      min: 16
     - dimension: tier_3
-      min: 51
       max: 100
+      min: 51
     - dimension: tier_4
-      min: 101
       max: 250
+      min: 101
     - dimension: tier_5
+      max: 1000
       min: 251
-      max: 500
-    # missing a final dimension for 501+
+    - dimension: tier_6
+      min: 1001
     min_consumption: 5
     usage_aggregation: average
-version: 0.1.1

--- a/tests/data/config_no_dimensions.yaml
+++ b/tests/data/config_no_dimensions.yaml
@@ -8,4 +8,4 @@ usage_metrics:
     consumption_reporting: volume
     min_consumption: 5
     usage_aggregation: average
-version: 1.1.1
+version: 0.1.1

--- a/tests/data/config_no_usage_metrics.yaml
+++ b/tests/data/config_no_usage_metrics.yaml
@@ -3,4 +3,4 @@ product_code: foo
 query_interval: 3600
 reporting_api_is_cumulative: true
 reporting_interval: 3600
-version: 1.1.1
+version: 0.1.1

--- a/tests/data/config_testing_mixed.yaml
+++ b/tests/data/config_testing_mixed.yaml
@@ -30,4 +30,4 @@ usage_metrics:
       min: 16
     min_consumption: 2
     usage_aggregation: maximum
-version: 1.1.1
+version: 0.1.1

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -34,6 +34,7 @@ from csp_billing_adapter.adapter import (
     setup_logging
 )
 from csp_billing_adapter.exceptions import (
+    CSPBillingAdapterException,
     NoMatchingVolumeDimensionError,
     FailedToSaveCSPConfigError
 )
@@ -79,6 +80,28 @@ def test_get_config(cba_pm, cba_config, cba_config_path, cba_log):
     config = get_config(cba_config_path, cba_pm.hook, cba_log)
 
     assert config == cba_config
+
+
+@pytest.mark.config('config_missing_version.yaml')
+def test_get_config_missing_version(
+    cba_pm,
+    cba_config_path,
+    cba_log
+):
+    """Verify correct operation of get_config()."""
+    with pytest.raises(CSPBillingAdapterException):
+        get_config(cba_config_path, cba_pm.hook, cba_log)
+
+
+@pytest.mark.config('config_bad_version.yaml')
+def test_get_config_bad_version(
+    cba_pm,
+    cba_config_path,
+    cba_log
+):
+    """Verify correct operation of get_config()."""
+    with pytest.raises(CSPBillingAdapterException):
+        get_config(cba_config_path, cba_pm.hook, cba_log)
 
 
 def test_initial_adapter_setup_no_errors(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -36,7 +36,7 @@ def test_get_config_from_good_config_file():
         good_config_file,
         pm.hook
     )
-    assert config.get('version') == '1.1.1'
+    assert config.get('version') == '0.1.1'
     assert config.product_code == 'foo'
 
 


### PR DESCRIPTION
This confirms the loaded config is compatible with the adapter. If the config is not compatible or version is missing an exception is raise and the adapter exist.