### PR TITLE
Prep for run in a VM

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include requirements.txt
 include requirements-test.txt
 include requirements-dev.txt
 
+recursive-include systemd *
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.coverage

--- a/systemd/csp-billing-adapter.service
+++ b/systemd/csp-billing-adapter.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=CSP usage reporting
+Wants=billing-data-service.service
+After=billing-data-service.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/csp-billing-adapter
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
For SUMa we will run in a VM and the adpater will run as a daemon process. Add a unit file and update the spec and Manifest files accordingly. We put the unit file into a subpackage to avoid dragging systemd into the container that only needs the executable.