### PR TITLE
Add support for using tox to run tests.

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,10 +19,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
+        pip install tox
+    - name: Lint with flake8
       run: |
-        tox
+        tox -e check
+    - name: Test with pytest
+      run: |
+        tox -e pytest
   
   testall:
 
@@ -40,7 +43,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
+        pip install tox
+    - name: Lint with flake8
       run: |
-        tox
+        tox -e check
+    - name: Test with pytest
+      run: |
+        tox -e pytest

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,15 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
-        pip install tox-gh-actions
-    - name: Lint with flake8
-      run: |
-        flake8 csp_billing_adapter
-        flake8 tests
-    - name: Test with pytest
-      run: |
-        pytest --cov=csp_billing_adapter
+        pip install tox tox-gh-actions
     - name: Test with tox
       run: |
         tox
@@ -48,15 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
-        pip install tox-gh-actions
-    - name: Lint with flake8
-      run: |
-        flake8 csp_billing_adapter
-        flake8 tests
-    - name: Test with pytest
-      run: |
-        pytest --cov=csp_billing_adapter
+        pip install tox tox-gh-actions
     - name: Test with tox
       run: |
         tox

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+        pip install tox-gh-actions
     - name: Lint with flake8
       run: |
         flake8 csp_billing_adapter
@@ -27,13 +28,16 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=csp_billing_adapter
+    - name: Test with tox
+      run: |
+        tox
   
   testall:
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v2
@@ -45,6 +49,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+        pip install tox-gh-actions
     - name: Lint with flake8
       run: |
         flake8 csp_billing_adapter
@@ -52,3 +57,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=csp_billing_adapter
+    - name: Test with tox
+      run: |
+        tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,13 +86,20 @@ you can use the `tox` command with no arguments:
 $ tox
 ```
 
-*NOTE:* By default tox is configured to run the pytest coverage tests for
-Python versions 3.6 to 3.12, inclusively, skipping any versions that aren't
-available. See [pyenv](https://github.com/pyenv/pyenv) for a solution that
-allows multiple versions of Python to be installed and available to support
+*NOTE1*: By default tox is configured to run the pytest coverage tests for
+all supported Python versions, skipping any versions that aren't available.
+See [pyenv](https://github.com/pyenv/pyenv) for a solution that allows
+multiple versions of Python to be installed and available to support local
 testing.
 
-If you just want to run the recommended code quality and verification tests
+*NOTE2*: On openSUSE Leap systems with a distro packages tox (version 2.9.1)
+if you have additional systemn Python versions installed, e.g. python3.10,
+you may see errors from tox related to trying to setup virtial environments
+for Python 3.10. If so it is recommened to create a virtialenv and install
+the latest version of tox available for your Python version, and use that
+tox command.
+
+If you want to run just the recommended code quality and verification tests
 using your system's default `python3` version, you can explicity select the
 `dev` testing environment when running tox:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,12 @@ Installation
 $ git clone https://github.com/SUSE-Enceladus/csp-billing-adapter.git
 $ cd csp-billing-adapter
 
-# Activate virtual Environment then install
-# csp-billing-adapter and dev dependences in editable mode
+# Create a Python Virtual Environment (venv) using:
+# $ python3 -m venv <path_to_venv>
+# Activate the Virtual Environment using:
+# $ . <path_to_venv>/bin/activate
+# And then install csp-billing-adapter in editable mode, along with it's
+# dependencies and the recommended dev support tools.
 $ pip install -e .[dev]
 ```
 
@@ -15,7 +19,7 @@ mode.
 
 *NOTE*: You will need to create a `~/.config/csp-billing-adapter.yaml` with
 appropriate configuration settings to be able to run the `csp-billing-adapter`
-command.
+command directly.
 
 Dev Requirements
 ================
@@ -63,6 +67,39 @@ $ git tag -a v{version}
 $ git push --tags
 ```
 
+Testing with tox
+================
+The `tox` tool automatically creates appropriately configured Python
+virtual environments that can be used to run the code quality and
+verification tests, avoiding the need for the user to create an
+appropriate Python virtual environment.
+
+The `tox.ini` settings should work with versions of tox >= 2.9.1; the
+latest tox version available for your system's Python version should
+be available in your virtualenv if you installed the developer tools
+using `pip install -e .[dev]`.
+
+If you want to run the recommended code quality and verification tests
+you can use the `tox` command with no arguments:
+
+```shell
+$ tox
+```
+
+*NOTE:* By default tox is configured to run the pytest coverage tests for
+Python versions 3.6 to 3.12, inclusively, skipping any versions that aren't
+available. See [pyenv](https://github.com/pyenv/pyenv) for a solution that
+allows multiple versions of Python to be installed and available to support
+testing.
+
+If you just want to run the recommended code quality and verification tests
+using your system's default `python3` version, you can explicity select the
+`dev` testing environment when running tox:
+
+```shell
+$ tox -e dev
+```
+
 Unit & Integration Tests
 ========================
 
@@ -74,6 +111,13 @@ The tests and coverage can be run directly via pytest.
 $ pytest --cov=csp_billing_adapter
 ```
 
+Alternatively you can explicitly run just the pytest coverage tests using
+`tox`:
+
+```shell
+$ tox -e pytest
+```
+
 Code Style
 ==========
 
@@ -81,6 +125,13 @@ Source should pass flake8 and pep8 standards.
 
 ```shell
 $ flake8 csp_billing_adapter
+```
+
+Alternatively you can explicitly run just the code quality checks using
+`tox`:
+
+```shell
+$ tox -e check
 ```
 
 Signing Commits

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements-test.txt
 
 bumpversion
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -14,17 +14,6 @@ envlist =
     py311,
     py312
 
-[gh-actions]
-# Which envs to run based upon Python version
-python =
-    3.6: py36, check
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-
 [testenv]
 wheel = true
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,71 @@
+[tox]
+minversion = 2.9.1
+basepython = python3
+# Only run an test env is the associated Python interpreter exists
+skip_missing_interpreters = True
+# List of envs to run if no env is specified
+envlist =
+    check,
+    py36,
+    py37,
+    py38,
+    py39,
+    py310,
+    py311,
+    py312
+
+[gh-actions]
+# Which envs to run based upon Python version
+python =
+    3.6: py36, check
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+
+[testenv]
+wheel = true
+basepython =
+    py36: {env:TOXPYTHON:python3.6}
+    py37: {env:TOXPYTHON:python3.7}
+    py38: {env:TOXPYTHON:python3.8}
+    py39: {env:TOXPYTHON:python3.9}
+    py310: {env:TOXPYTHON:python3.10}
+    py311: {env:TOXPYTHON:python3.11}
+    py312: {env:TOXPYTHON:python3.12}
+    {check,dev,pytest}: {env:TOXPYTHON:python3}
+description = Basic command test
+setenv =
+    PYTHONUNBUFFERED=yes
+passenv =
+    *
+usedevelop = true
+deps =
+    -rrequirements-test.txt
+# default to running pytest with coverage if no command is specified
+# on tox command line
+commands =
+    {posargs:pytest --cov=csp_billing_adapter}
+
+[testenv:check]
+description = Check code compliance
+skip_install = true
+commands =
+    flake8 csp_billing_adapter
+    flake8 tests
+
+[testenv:dev]
+description = Run developer tests (check, pytest)
+deps =
+    -rrequirements-dev.txt
+commands =
+    flake8 csp_billing_adapter
+    flake8 tests
+    pytest --cov=csp_billing_adapter
+
+[testenv:pytest]
+description = Run tests
+commands =
+    pytest --cov=csp_billing_adapter


### PR DESCRIPTION
Added a tox.ini that defines testing environments for Python versions 3.6 through 3.12 pytest coverage testing, as well as the code quality tests.

This should work with the versions of tox available for actively supported openSUSE, SLE and Ubuntu distributions.

Updated CONTRIBUTING.MD with instructions for how to use tox to drive the tests. Also added some additional verbiage in the initial installation instructions advising how to create a venv.

Updated Github Actions workflows to enable using tox to run the tests.

Relates: #116