### PR TITLE
Handle status dictionary in meter billing response

### DIFF
--- a/csp_billing_adapter/csp_cache.py
+++ b/csp_billing_adapter/csp_cache.py
@@ -110,25 +110,26 @@ def add_usage_record(record: dict, cache: dict) -> None:
 
 def cache_meter_record(
     cache: dict,
-    record_ids: dict,
+    status: dict,
     dimensions: dict,
     metering_time: str
 ) -> None:
     """
     Update the cache data store to reflect the fact that a successful CSP
-    metering operation was performed, storing the record_ids returned by
+    metering operation was performed, storing the status returned by
     the CSP, the billing dimensions submitted in the metering operation,
     the time at which it was performed, and the time after which the next
     billing operation will be performed.
 
-    :param record_ids:
-        A mapping of dimensions to record ids returned by the CSP to track
-        the billing submission.
+    :param status:
+        A mapping of dimensions to status. This includes record ids
+        returned by the CSP to track the billing submission, status,
+        and any error messages.
     :param dimensions: The billing dimensions submitted to the CSP.
     :param metering_time: The time at which the submission occurred.
     """
     cache['last_bill'] = {
         'dimensions': dimensions,
-        'record_ids': record_ids,
+        'status': status,
         'metering_time': metering_time
     }

--- a/csp_billing_adapter/local_csp.py
+++ b/csp_billing_adapter/local_csp.py
@@ -49,7 +49,14 @@ def meter_billing(
         log.warning("Simulating failed metering operation")
         raise Exception('Unable to submit meter usage. Payment not billed!')
     else:
-        return str(uuid.uuid4().hex)
+        status = {}
+        for dimension, quantity in dimensions.items():
+            status[dimension] = {
+                'record_id': str(uuid.uuid4().hex),
+                'status': 'succeeded'
+            }
+
+        return status
 
 
 @csp_billing_adapter.hookimpl(trylast=True)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -302,7 +302,7 @@ def test_event_loop_handler(
     assert cache['usage_records'] == []
     assert cache['last_bill'] != {}
     assert 'dimensions' in cache['last_bill']
-    assert 'record_ids' in cache['last_bill']
+    assert 'status' in cache['last_bill']
     assert 'metering_time' in cache['last_bill']
 
     # The csp_config should now contain usage and last_billed
@@ -345,7 +345,7 @@ def test_event_loop_handler(
     assert len(cache['usage_records']) == 1
     assert cache['last_bill'] != {}
     assert 'dimensions' in cache['last_bill']
-    assert 'record_ids' in cache['last_bill']
+    assert 'status' in cache['last_bill']
     assert 'metering_time' in cache['last_bill']
 
     # An error should have been added to the errors list in the

--- a/tests/unit/test_csp_cache.py
+++ b/tests/unit/test_csp_cache.py
@@ -150,7 +150,16 @@ def test_cache_meter_record(cba_pm, cba_config):
         }
     ]
     test_dimensions = {'dim1': 1, 'dim2': 2}
-    test_record_ids = {'dim1': 'some_record_id', 'dim2': 'some_record_id'}
+    test_status = {
+        'dim1': {
+            'record_id': 'some_record_id',
+            'status': 'submitted'
+        },
+        'dim2': {
+            'record_id': 'some_record_id',
+            'status': 'submitted'
+        }
+    }
 
     # cache should initially be empty
     assert cba_pm.hook.get_cache(config=cba_config) == {}
@@ -180,14 +189,14 @@ def test_cache_meter_record(cba_pm, cba_config):
     # usage record
     cache_meter_record(
         cache=cache,
-        record_ids=test_record_ids,
+        status=test_status,
         dimensions=test_dimensions,
         metering_time=test_time1
     )
 
     assert cache['last_bill'] != {}
-    assert 'record_ids' in cache['last_bill']
-    assert cache['last_bill']['record_ids'] == test_record_ids
+    assert 'status' in cache['last_bill']
+    assert cache['last_bill']['status'] == test_status
     assert 'dimensions' in cache['last_bill']
     assert cache['last_bill']['dimensions'] == test_dimensions
     assert 'metering_time' in cache['last_bill']

--- a/tests/unit/test_local_csp.py
+++ b/tests/unit/test_local_csp.py
@@ -33,7 +33,7 @@ from csp_billing_adapter.local_csp import (
 
 
 def test_meter_billing_ok(cba_config):
-    test_dimensions = {}
+    test_dimensions = {'dim_1': 10}
     test_timestamp = datetime.now()
     test_uuid = uuid.uuid4()
     test_randval = 1
@@ -46,14 +46,14 @@ def test_meter_billing_ok(cba_config):
             'csp_billing_adapter.local_csp.randrange',
             return_value=test_randval
         ):
-            billing_id = meter_billing(
+            status = meter_billing(
                 cba_config,
                 test_dimensions,
                 test_timestamp,
                 dry_run=False
             )
 
-            assert billing_id == str(test_uuid.hex)
+            assert status['dim_1']['record_id'] == str(test_uuid.hex)
 
 
 def test_meter_billing_error(cba_config):


### PR DESCRIPTION
The response is a structured dictionary with status based on the billed dimensions. Each dimension hash may contain record_id, status and any errors. Status can be submitted or failed.

I think this matches the agreement from discussion. This drops the string + dict handling pending release time. If this can get merged to main before first release it's okay as is. If not it will need to re-introduce the multi-type response handling to work with both "API" versions.