### PR TITLE
Handle legacy meter billing return type

### DIFF
--- a/csp_billing_adapter/bill_utils.py
+++ b/csp_billing_adapter/bill_utils.py
@@ -460,14 +460,18 @@ def get_errors(status: dict) -> list:
     return errors
 
 
-def create_billing_status(record_id: str, dimension: str) -> dict:
+def create_billing_status(
+    record_id: str,
+    dimension: str,
+    status: str = 'submitted'
+) -> dict:
     """
     Returns a billing status dictionary from the provided input.
     """
     billing_status = {
         dimension: {
             'record_id': record_id,
-            'status': 'submitted'
+            'status': status
         }
     }
 

--- a/csp_billing_adapter/bill_utils.py
+++ b/csp_billing_adapter/bill_utils.py
@@ -460,6 +460,20 @@ def get_errors(status: dict) -> list:
     return errors
 
 
+def create_billing_status(record_id: str, dimension: str) -> dict:
+    """
+    Returns a billing status dictionary from the provided input.
+    """
+    billing_status = {
+        dimension: {
+            'record_id': record_id,
+            'status': 'submitted'
+        }
+    }
+
+    return billing_status
+
+
 def process_metering(
     hook,
     config: Config,
@@ -573,7 +587,16 @@ def process_metering(
         csp_config['errors'].append(str(error))
         csp_config['billing_api_access_ok'] = False
     else:
+        if isinstance(billing_status, str):
+            # If billing status is a string it is the record id
+            # and we can assume that only one dimension was billed.
+            billing_status = create_billing_status(
+                record_id=billing_status,
+                dimension=next(iter(billed_dimensions))
+            )
+
         errors = get_errors(billing_status)
+
         if errors:
             for error in errors:
                 log.exception(error)

--- a/csp_billing_adapter/local_csp.py
+++ b/csp_billing_adapter/local_csp.py
@@ -56,6 +56,9 @@ def meter_billing(
                 'error': 'Simulating failed metering operation',
                 'status': 'failed'
             }
+    elif seed == 24:
+        log.info('Simulating legacy return type')
+        status = str(uuid.uuid4().hex)
     else:
         for dimension, quantity in dimensions.items():
             status[dimension] = {


### PR DESCRIPTION
If the return type for meter billing is a string then assume it is record id and there is only one dimension being billed. Create a billing status dictionary with this information.

Fixes #122 and adds back the final piece to resolve #112.