### PR TITLE
Update message when records list is empty

### DIFF
--- a/csp_billing_adapter/csp_cache.py
+++ b/csp_billing_adapter/csp_cache.py
@@ -95,7 +95,7 @@ def add_usage_record(record: dict, cache: dict) -> None:
     """
 
     if not cache.get('usage_records', []):
-        log.info('Initial usage record: %s', record)
+        log.info('Appending usage record: %s', record)
         cache['usage_records'] = [record]
     else:
         last_record_time = cache['usage_records'][-1]['reporting_time']


### PR DESCRIPTION
Every billing cycle the records are emptied. Printing "initial" usage record at the beginning of each cycle is confusing.