### PR TITLE
Only sleep at initial deployment

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -198,9 +198,12 @@ def initial_adapter_setup(
 
     if not cache:
         cache = create_cache(hook, config)
+        initial_deploy = True
+    else:
+        initial_deploy = False
 
     log.info("Adapter setup complete")
-    return cache, csp_config
+    return cache, csp_config, initial_deploy
 
 
 def event_loop_handler(
@@ -391,11 +394,16 @@ def main() -> None:
 
         update_logger_from_config(config, log)
 
-        cache, csp_config = initial_adapter_setup(pm.hook, config, log)
+        cache, csp_config, initial_deploy = initial_adapter_setup(
+            pm.hook,
+            config,
+            log
+        )
 
         metering_test(pm.hook, config, log, csp_config)
 
-        time.sleep(config.query_interval)  # wait 1 cycle for usage data
+        if initial_deploy:
+            time.sleep(config.query_interval)  # wait 1 cycle for usage data
 
         while True:
             start = get_now()

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -123,6 +123,13 @@ def test_initial_adapter_setup_no_errors(
     csp_config = cba_pm.hook.get_csp_config(config=cba_config)
     assert csp_config == setup_csp_config
 
+    setup_cache, setup_csp_config, initial_deploy = initial_adapter_setup(
+        cba_pm.hook,
+        cba_config,
+        cba_log
+    )
+    assert not initial_deploy
+
 
 @mock.patch('csp_billing_adapter.adapter.time.sleep')
 def test_initial_adapter_setup_csp_config_errors(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -107,11 +107,13 @@ def test_initial_adapter_setup_no_errors(
     Verify that the initial_adapter_setup() works correctly using
     in-memory plugins.
     """
-    setup_cache, setup_csp_config = initial_adapter_setup(
+    setup_cache, setup_csp_config, initial_deploy = initial_adapter_setup(
         cba_pm.hook,
         cba_config,
         cba_log
     )
+
+    assert initial_deploy
     assert setup_cache != {}
     assert setup_csp_config != {}
 
@@ -176,7 +178,7 @@ def test_initial_adapter_setup_cache_errors(
         'get_cache',
         side_effect=error
     ):
-        cache, csp_config, = initial_adapter_setup(
+        cache, csp_config, initial_deploy = initial_adapter_setup(
             cba_pm.hook,
             cba_config,
             cba_log
@@ -585,7 +587,7 @@ def test_metering_test_attrubute_error_handling(
         "attribute 'usage_metrics'"
     )
 
-    cache, csp_config = initial_adapter_setup(
+    cache, csp_config, initial_deploy = initial_adapter_setup(
         cba_pm.hook,
         cba_config,
         cba_log
@@ -617,7 +619,7 @@ def test_metering_test_key_error_handling(
         "'dimensions'"
     )
 
-    cache, csp_config = initial_adapter_setup(
+    cache, csp_config, initial_deploy = initial_adapter_setup(
         cba_pm.hook,
         cba_config,
         cba_log
@@ -651,7 +653,7 @@ def test_metering_test_meter_billing_failure(
         f"{str(err_exc)}"
     )
 
-    cache, csp_config = initial_adapter_setup(
+    cache, csp_config, initial_deploy = initial_adapter_setup(
         cba_pm.hook,
         cba_config,
         cba_log
@@ -695,7 +697,7 @@ def test_metering_test_meter_billing_and_update_csp_config_failure(
         f"{str(err_exc)}"
     )
 
-    cache, csp_config = initial_adapter_setup(
+    cache, csp_config, initial_deploy = initial_adapter_setup(
         cba_pm.hook,
         cba_config,
         cba_log


### PR DESCRIPTION
Sleeping on a container rollout risks missing usage data.