### PR TITLE
Skip invalid records

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -231,7 +231,7 @@ def event_loop_handler(
         csp_config['errors'].append(f'Usage data retrieval failed: {exc}')
 
     if usage:
-        add_usage_record(usage, cache)
+        add_usage_record(usage, cache, config.billing_interval)
         csp_config['base_product'] = usage.get('base_product', '')
 
     log.debug(

--- a/csp_billing_adapter/csp_cache.py
+++ b/csp_billing_adapter/csp_cache.py
@@ -32,7 +32,9 @@ from csp_billing_adapter.utils import (
     date_to_string,
     get_next_bill_time,
     get_date_delta,
-    retry_on_exception
+    retry_on_exception,
+    get_prev_bill_time,
+    string_to_date
 )
 
 log = logging.getLogger('CSPBillingAdapter')
@@ -82,7 +84,37 @@ def create_cache(hook, config: Config) -> dict:
     return cache
 
 
-def add_usage_record(record: dict, cache: dict) -> None:
+def record_valid(
+    reporting_time: str,
+    next_bill_time: str,
+    billing_interval: str
+):
+    """
+    Return True if the record reporting time is after the range start
+
+    This prevents any record that is older than the current billing
+    period from ending up in cache.
+
+    :param reporting_time:
+        The time the record was reported from product.
+    :param next_bill_time:
+        The end of the current billing period.
+    :param billing_interval:
+        The cadence for metering billing.
+    """
+    range_end = string_to_date(next_bill_time)
+    range_start = get_prev_bill_time(
+        range_end,
+        billing_interval
+    )
+    return range_start <= string_to_date(reporting_time)
+
+
+def add_usage_record(
+    record: dict,
+    cache: dict,
+    billing_interval: str
+) -> None:
     """
     Add a new 'record' to the cache data store's usage_records list,
     avoiding duplicate records by ensuring that the new record's
@@ -92,7 +124,17 @@ def add_usage_record(record: dict, cache: dict) -> None:
         The record to add to the cache.
     :param cache:
         Cache to add the record to.
+    :param billing_interval:
+        The cadence for meter billing.
     """
+    valid = record_valid(
+        record['reporting_time'],
+        cache['next_bill_time'],
+        billing_interval
+    )
+    if not valid:
+        log.info('Skipping invalid usage record: %s', record)
+        return
 
     if not cache.get('usage_records', []):
         log.info('Initial usage record: %s', record)

--- a/csp_billing_adapter/csp_cache.py
+++ b/csp_billing_adapter/csp_cache.py
@@ -88,7 +88,7 @@ def record_valid(
     reporting_time: str,
     next_bill_time: str,
     billing_interval: str
-):
+) -> bool:
     """
     Return True if the record reporting time is after the range start
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -350,13 +350,9 @@ def test_event_loop_handler(
         csp_config
     )
 
-    # A new usage record should have been added to the usage
-    # records list in the cache, and the last_bill entries should
-    # still be present.
+    # The last_bill entries should still be present.
     cache = cba_pm.hook.get_cache(config=cba_config)
     assert cache != {}
-    assert cache['usage_records'] != []
-    assert len(cache['usage_records']) == 1
     assert cache['last_bill'] != {}
     assert 'dimensions' in cache['last_bill']
     assert 'billing_status' in cache['last_bill']

--- a/tests/unit/test_bill_utils.py
+++ b/tests/unit/test_bill_utils.py
@@ -544,11 +544,15 @@ def test_process_metering(mock_sleep, cba_pm, cba_config):
         billing_period_only=False
     )
 
+    # add early record
+    test_cache['usage_records'] = [test_usage_data[0]]
+
     # add generated usage records to cache
-    for record in test_usage_data:
+    for record in test_usage_data[1:]:
         add_usage_record(
             record=record,
-            cache=test_cache
+            cache=test_cache,
+            billing_interval=cba_config.billing_interval
         )
 
     assert test_cache["usage_records"] == test_usage_data
@@ -715,7 +719,8 @@ def test_process_metering_no_matching_dimensions(cba_pm, cba_config):
     for record in test_usage_data:
         add_usage_record(
             record=record,
-            cache=test_cache
+            cache=test_cache,
+            billing_interval=cba_config.billing_interval
         )
 
     assert test_cache["usage_records"] == test_usage_data
@@ -810,7 +815,8 @@ def test_process_metering_legacy_return(mock_sleep, cba_pm, cba_config):
     for record in test_usage_data:
         add_usage_record(
             record=record,
-            cache=test_cache
+            cache=test_cache,
+            billing_interval=cba_config.billing_interval
         )
 
     account_info = {'customer': 'data'}


### PR DESCRIPTION
Any record that is older than the current billing period would be orphaned and lead to "memory leak" of cache.

This could happen if the query interval is shorter than the products usage updates. A metered billing could empty the records in cache and the adapter picks up an old usage record before the product cycles.