### PR TITLE
Add get version hook spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ has the following format:
       "pkcs7": "pkcs7",
       "cloud_provider": "string"
     },
-    "base_product": string
+    "base_product": string,
+    "versions": {
+        "core": "1.2.3",
+        ...
+    }
 }
 ```
 
@@ -124,6 +128,9 @@ the running container/vm from the CSP. The format is dependent on the CSP.
 
 **base_product:** This is a CPE product + version string in the following
 format `cpe:/o:suse:product:v1.2.3`.
+
+**versions:** This is a dictionary mapping installed plugins to their
+respective version. The main package is listed as "core".
 
 ### cache
 

--- a/csp_billing_adapter/hookimpls.py
+++ b/csp_billing_adapter/hookimpls.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Pluggy hook implementations for core package."""
+
+import csp_billing_adapter
+
+
+@csp_billing_adapter.hookimpl
+def get_version():
+    """
+    Returns the version of the current plugin.
+    """
+    version = csp_billing_adapter.__version__
+    return ('core', version)

--- a/csp_billing_adapter/hookspecs.py
+++ b/csp_billing_adapter/hookspecs.py
@@ -50,3 +50,12 @@ def load_defaults(defaults: dict) -> None:
     :param defaults:
         The hash into which the defaults will be loaded.
     """
+
+
+@hookspec()
+def get_version() -> (str, str):
+    """
+    Returns the version of the current plugin.
+
+    :return: A tuple with the plugin name and the version.
+    """

--- a/csp_billing_adapter/local_csp.py
+++ b/csp_billing_adapter/local_csp.py
@@ -83,3 +83,9 @@ def get_account_info(config: Config) -> str:
         'arch': 'x86_64',
         'cloud_provider': 'local'
     }
+
+
+@csp_billing_adapter.hookimpl
+def get_version():
+    version = csp_billing_adapter.__version__
+    return ('test_csp_plugin', version)

--- a/tests/unit/test_hookimpls.py
+++ b/tests/unit/test_hookimpls.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Unit tests for the csp_billing_adapter.hookimpls
+#
+
+from csp_billing_adapter.hookimpls import get_version
+
+
+def test_get_version():
+    version = get_version()
+    assert version[0] == 'core'
+    assert version[1]

--- a/tests/unit/test_local_csp.py
+++ b/tests/unit/test_local_csp.py
@@ -28,7 +28,8 @@ from pytest import raises
 from csp_billing_adapter.local_csp import (
     get_account_info,
     get_csp_name,
-    meter_billing
+    meter_billing,
+    get_version
 )
 
 
@@ -92,3 +93,9 @@ def test_get_account_info(cba_config):
 
     account_info = get_account_info(cba_config)
     assert account_info == test_account_info
+
+
+def test_get_version():
+    version = get_version()
+    assert version[0] == 'test_csp_plugin'
+    assert version[1]


### PR DESCRIPTION
And an imlementation for core version. Returns a tuple with plugin name and plugin version. Each plugin is expected to implement the hook and all data is aggregated into the external API.