### PR TITLE
Clear billing status with an empty dictionary

### DIFF
--- a/csp_billing_adapter/bill_utils.py
+++ b/csp_billing_adapter/bill_utils.py
@@ -610,11 +610,7 @@ def process_metering(
             cache['billing_status'] = billing_status
             return
         else:
-            # clear any previous failed state
-            try:
-                del cache['billing_status']
-            except KeyError:
-                pass
+            cache['billing_status'] = {}
 
         log.info(
             "Metering submitted, billing status: %s",


### PR DESCRIPTION
Deleting the key does not work during persistence because dictionary merge is used. When merging if the key has been deleted no changes are made to the persisted value.