### PR TITLE
Cleanup docstring and readme

### DIFF
--- a/csp_billing_adapter/archive_hookspecs.py
+++ b/csp_billing_adapter/archive_hookspecs.py
@@ -39,16 +39,16 @@ def get_metering_archive(config: Config) -> list:
 
     :param config: The application configuration dictionary
     :return: Return a list of the archive data which contains a history
-             of recent meterings. The length of this data is determined
-             by application config.
+             of recent data usage and meterings. The length of this data
+             is determined by application config.
     """
 
 
 @hookspec(firstresult=True)
 def save_metering_archive(config: Config, archive_data: list) -> None:
     """
-    Saves the metering archive data to stateful storage
+    Saves the archive data to stateful storage
 
     :param config: The application configuration dictionary
-    :param archive_data: A list of metering archive data
+    :param archive_data: A list of usage data and meterings
     """

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ reporting_interval:
     Sets the time in seconds when the csp-billing-adapter reports to the CSP API. The values the csp-billing-adapter reports are determined by a combination of the settings for `reporting_api_is_cumulative` and `billing_interval`.
 
 archive_retention_period:
-    Sets the time in months that metering data is retained in the data archive.
+    Sets the time in months that meterings and usage records are retained in the data archive.
 
 usage_metrics: 
 


### PR DESCRIPTION
To clarify what will be stored in the data archive. This will contain a list of meterings and also the relevant usage records for each metering.