### PR TITLE
Catch and log non-fatal archive error

### DIFF
--- a/csp_billing_adapter/bill_utils.py
+++ b/csp_billing_adapter/bill_utils.py
@@ -665,8 +665,12 @@ def process_metering(
                 'usage_records': billable_records
             }
 
-            archive_record(
-                hook,
-                config,
-                billing_record
-            )
+            try:
+                archive_record(
+                    hook,
+                    config,
+                    billing_record
+                )
+            except Exception as error:
+                # Non-fatal error is only logged
+                log.exception(error)

--- a/tests/unit/test_bill_utils.py
+++ b/tests/unit/test_bill_utils.py
@@ -801,8 +801,16 @@ def test_create_billing_status():
 
 
 @mark.config('config_testing_mixed.yaml')
+@mock.patch('csp_billing_adapter.bill_utils.archive_record')
 @mock.patch('csp_billing_adapter.utils.time.sleep')
-def test_process_metering_legacy_return(mock_sleep, cba_pm, cba_config):
+def test_process_metering_legacy_return(
+    mock_sleep,
+    mock_archive,
+    cba_pm,
+    cba_config
+):
+    mock_archive.side_effect = Exception('Failed to save archive!')
+
     # initialise the cache
     create_cache(
         hook=cba_pm.hook,


### PR DESCRIPTION
But do not re-raise or add error to csp config which marks the adapter as in an unsupported state. Archive failure is not critical.