### PR TITLE
Fix the dependency of the service subpackage

### DIFF
--- a/csp-billing-adapter.spec
+++ b/csp-billing-adapter.spec
@@ -65,7 +65,7 @@ to report billing information to the CSP API.
 %package service
 Summary:        The unit file for csp billing adapter
 Group:          System/Management
-Requires:       python3-csp-billing-adapter = %{version}
+Requires:       %{python_module csp-billing-adapter} = %{version}
 # pkg-config is needed to find correct systemd unit dir
 BuildRequires:  pkg-config
 BuildRequires:  pkgconfig(systemd)


### PR DESCRIPTION
With the switch to other Python interpreters to build the code the service cannot explicitly depend on the code being built with the Python 3.6 interpreter.