### PR TITLE
Support daily billing interval to enable testing on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ billing. The following is what a config file may look like:
 ```
 version: 1.1.1
 api: THE_PATH_WHERE_WE_GET_THE_UNIT_INFORMATION
-billing_interval: monthly|hourly
+billing_interval: monthly|daily|hourly
 query_interval: Time in seconds
 product_code: TBD
 archive_retention_period: 6
@@ -256,9 +256,11 @@ reporting interval is more frequent than the billing interval. This is where
 an application is expected to provide a "heartbeat" on a shorter interval than
 the product billing period.
 
-The billing interval has two possible values; monthly and hourly. When set to
-hourly the adapter bills usage every hour. And when set to monthly the adapter
-aggregates usage based on the query interval and bills once a month.
+The billing interval can be either monthly, daily, or hourly. When set to
+hourly the adapter bills usage every hour. When set to daily the
+adapter aggregates usage based on the query interval and bills once a day.
+Likewise, when set to monthly the adapter aggregates usage based on the query
+interval and bills once a month.
 
 ### Save data
 

--- a/csp_billing_adapter/utils.py
+++ b/csp_billing_adapter/utils.py
@@ -92,6 +92,8 @@ def get_relative_period_delta(billing_interval: str):
 
     if billing_interval == 'monthly':
         kwargs['months'] = 1
+    elif billing_interval == 'daily':
+        kwargs['days'] = 1
     elif billing_interval == 'hourly':
         kwargs['hours'] = 1
     elif billing_interval == 'test':

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -89,6 +89,12 @@ def test_good_get_next_bill_time_hourly():
         'hourly') == \
         datetime.datetime(2023, 4, 20, 14, 8, 30)
 
+def test_good_get_next_bill_time_daily():
+    """Test working utils.get_next_bill_time"""
+    assert utils.get_next_bill_time(
+        datetime.datetime(2023, 4, 20, 13, 8, 30),
+        'daily') == \
+        datetime.datetime(2023, 4, 21, 13, 8, 30)
 
 def test_good_get_next_bill_time_monthly():
     """Test working utils.get_next_bill_time"""
@@ -113,6 +119,12 @@ def test_good_get_prev_bill_time_hourly():
         'hourly') == \
         datetime.datetime(2023, 4, 20, 13, 8, 30)
 
+def test_good_get_prev_bill_time_daily():
+    """Test working utils.get_prev_bill_time"""
+    assert utils.get_prev_bill_time(
+        datetime.datetime(2023, 4, 21, 13, 8, 30),
+        'daily') == \
+        datetime.datetime(2023, 4, 20, 13, 8, 30)
 
 def test_good_get_prev_bill_time_monthly():
     """Test working utils.get_prev_bill_time"""


### PR DESCRIPTION
Since Azure only allow submitting usage for no more than once a day, or we'll get a HTTP 400 "Invalid usage state" error. See https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-metered-billing

Signed-off-by: yeey <gyee@suse.com>
