### PR TITLE
Add obsoletes to spec file

### DIFF
--- a/csp-billing-adapter.spec
+++ b/csp-billing-adapter.spec
@@ -56,6 +56,7 @@ Requires(post): update-alternatives
 Requires(postun): update-alternatives
 %endif
 BuildArch:      noarch
+Obsoletes:      python3-csp-billing-adapter < %{version}
 %python_subpackages
 
 %description


### PR DESCRIPTION
The package builds for python 3.## version instead of only python3