### PR TITLE
Add env var to override log level

### DIFF
--- a/csp_billing_adapter/adapter.py
+++ b/csp_billing_adapter/adapter.py
@@ -117,7 +117,13 @@ def get_config(
 def update_logger_from_config(config: Config, log: logging.Logger):
     """Update the logger based on configuration file options."""
     current_level = log.getEffectiveLevel()
-    log.setLevel(config.get('logging', {}).get('level', current_level))
+
+    log_level = (
+        os.environ.get('LOG_LEVEL') or
+        config.get('logging', {}).get('level') or
+        current_level
+    )
+    log.setLevel(log_level)
 
     if current_level != log.getEffectiveLevel():
         log.info(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -76,18 +76,21 @@ def test_setup_logging():
     assert log.name == "CSPBillingAdapter"
 
 
-def test_update_logger_from_config():
+def test_update_logger_from_config(monkeypatch):
     """Verify logging is updated correctly."""
     log = setup_logging()
     update_logger_from_config({'logging': {'level': 'WARN'}}, log)
-
     assert log.getEffectiveLevel() == 30
 
     log = setup_logging()
     expected_level = log.getEffectiveLevel()
     update_logger_from_config({}, log)
-
     assert log.getEffectiveLevel() == expected_level
+
+    monkeypatch.setenv('LOG_LEVEL', 'DEBUG')
+    update_logger_from_config({'logging': {'level': 'WARN'}}, log)
+    assert log.getEffectiveLevel() == 10
+    monkeypatch.delenv('LOG_LEVEL')
 
 
 def test_get_config(cba_pm, cba_config, cba_config_path, cba_log):


### PR DESCRIPTION
If the env var value is set it is preferred over the config value.